### PR TITLE
Do not enforce required attributes if attributecollection is supplied.

### DIFF
--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/parser/docitems/CfmlTagItem.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/parser/docitems/CfmlTagItem.java
@@ -77,7 +77,9 @@ public class CfmlTagItem extends TagItem {
 		for(int i = 0; i < params.length; i++) {
 			Parameter currParam = (Parameter)params[i];
 			
-			if(currParam.isRequired() && !(itemAttributes.containsKey(currParam.getName().toLowerCase()) || itemAttributes.containsKey(currParam.getName().toUpperCase()))) {
+			if (currParam.isRequired()
+					&& !(itemAttributes.containsKey(currParam.getName().toLowerCase()) || itemAttributes.containsKey(currParam.getName()
+							.toUpperCase())) && !itemAttributes.containsKey("attributecollection")) {
 				this.parseMessages.addMessage(new ParseError(lineNumber, startPosition, endPosition, itemData,
 					"The attribute \'" + currParam.getName() + "\' is compulsory for the <" + this.itemName + "> tag." + attributesFound));
 			}


### PR DESCRIPTION
Fix issue where an error was showing if "attributecollection" was used.
