### PR TITLE
Feature/replace deprecated asserts

### DIFF
--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/CFJavaFileStorage.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/CFJavaFileStorage.java
@@ -11,7 +11,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.jface.text.Assert;
+import org.eclipse.core.runtime.Assert;
 
 public class CFJavaFileStorage implements IStorage {
 

--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/NonRuleBasedDamagerRepairer.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/NonRuleBasedDamagerRepairer.java
@@ -34,7 +34,7 @@ import org.eclipse.jface.text.TextAttribute;
 import org.eclipse.jface.text.TextPresentation;
 import org.eclipse.jface.text.presentation.IPresentationDamager;
 import org.eclipse.jface.text.presentation.IPresentationRepairer;
-import org.eclipse.jface.util.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.swt.custom.StyleRange;
 
 public class NonRuleBasedDamagerRepairer implements IPresentationDamager, IPresentationRepairer {

--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/contentassist/CFEContentAssist.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/contentassist/CFEContentAssist.java
@@ -48,7 +48,7 @@ import org.eclipse.jface.text.contentassist.CompletionProposal;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
-import org.eclipse.jface.util.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.viewers.ISelection;
 
 

--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/CFEPartition.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/CFEPartition.java
@@ -29,7 +29,7 @@
  */
 package org.cfeclipse.cfml.editors.partitioner;
 
-import org.eclipse.jface.text.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.text.TypedPosition;
 /**
  * Class description...

--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/CFEPartitioner.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/CFEPartitioner.java
@@ -39,7 +39,7 @@ import org.cfeclipse.cfml.CFMLPlugin;
 import org.cfeclipse.cfml.editors.partitioner.scanners.CFPartitionScanner;
 import org.cfeclipse.cfml.plugindebug.DebugSettings;
 import org.cfeclipse.cfml.plugindebug.DebugUtils;
-import org.eclipse.jface.text.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.BadPositionCategoryException;
 import org.eclipse.jface.text.DocumentEvent;

--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/scanners/rules/CFScriptComponentEndRule.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/scanners/rules/CFScriptComponentEndRule.java
@@ -9,7 +9,7 @@ package org.cfeclipse.cfml.editors.partitioner.scanners.rules;
 import java.util.regex.Pattern;
 
 import org.cfeclipse.cfml.editors.partitioner.FakeTagData;
-import org.eclipse.jface.text.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.text.rules.ICharacterScanner;
 import org.eclipse.jface.text.rules.IPredicateRule;
 import org.eclipse.jface.text.rules.IToken;

--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/scanners/rules/CFScriptComponentRule.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/scanners/rules/CFScriptComponentRule.java
@@ -10,7 +10,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.cfeclipse.cfml.editors.partitioner.TagData;
-import org.eclipse.jface.text.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.text.rules.ICharacterScanner;
 import org.eclipse.jface.text.rules.IPredicateRule;
 import org.eclipse.jface.text.rules.IToken;

--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/scanners/rules/CustomTagRule.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/scanners/rules/CustomTagRule.java
@@ -8,7 +8,7 @@ package org.cfeclipse.cfml.editors.partitioner.scanners.rules;
 
 
 import org.cfeclipse.cfml.editors.partitioner.TagData;
-import org.eclipse.jface.text.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.text.rules.ICharacterScanner;
 import org.eclipse.jface.text.rules.IPredicateRule;
 import org.eclipse.jface.text.rules.IToken;

--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/scanners/rules/NamedTagRule.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/scanners/rules/NamedTagRule.java
@@ -10,7 +10,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.cfeclipse.cfml.editors.partitioner.TagData;
-import org.eclipse.jface.text.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.text.rules.ICharacterScanner;
 import org.eclipse.jface.text.rules.IPredicateRule;
 import org.eclipse.jface.text.rules.IToken;

--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/scanners/rules/ShowWhitespaceRule.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/editors/partitioner/scanners/rules/ShowWhitespaceRule.java
@@ -1,6 +1,6 @@
 package org.cfeclipse.cfml.editors.partitioner.scanners.rules;
 
-//import org.eclipse.jface.text.Assert;
+//import org.eclipse.core.runtime.Assert;
 import org.cfeclipse.cfml.editors.ColorManager;
 import org.cfeclipse.cfml.preferences.CFMLColorsPreferenceConstants;
 import org.cfeclipse.cfml.preferences.CFMLPreferenceManager;

--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/external/ExternalMarkerAnnotationModel.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/external/ExternalMarkerAnnotationModel.java
@@ -16,7 +16,7 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jface.text.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.ui.texteditor.AbstractMarkerAnnotationModel;
 
 /**

--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/preferences/OverlayPreferenceStore.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/preferences/OverlayPreferenceStore.java
@@ -26,7 +26,7 @@ package org.cfeclipse.cfml.preferences;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceStore;
-import org.eclipse.jface.text.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 

--- a/org.cfeclipse.cfml/src/org/cfeclipse/cfml/preferences/StatusInfo.java
+++ b/org.cfeclipse.cfml/src/org/cfeclipse/cfml/preferences/StatusInfo.java
@@ -25,7 +25,7 @@
 package org.cfeclipse.cfml.preferences;
 
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.jface.util.Assert;
+import org.eclipse.core.runtime.Assert;
 
 class StatusInfo
 	implements IStatus


### PR DESCRIPTION
There are 2 Assert classes that were deprecated and removed. These are causing the editor to fail to load when you open the Coldfusion editors. According to the documentation, this is the appropriate change. Making this change fixes the editor crash when I run locally.